### PR TITLE
Fix/refactoring

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -41,6 +41,8 @@ sickApi.interceptors.request.use((config) => {
   console.info("calling api");
   const toCacheKey = `${SICK_CACHE_KEY_PREFIX}-${config.url}`;
   const cachedData = getCacheData(toCacheKey);
+  if (cachedData.expireTime)
+    deleteExpiredSearchedCacheData(toCacheKey, cachedData.expireTime);
   if (cachedData.data.length > 0) {
     return {
       ...config,
@@ -56,12 +58,9 @@ sickApi.interceptors.request.use((config) => {
 sickApi.interceptors.response.use((response) => {
   const toCacheKey = `${SICK_CACHE_KEY_PREFIX}-${response.config.url}`;
   const cachedData = getCacheData(toCacheKey);
-  if (cachedData.data.length > 0 && cachedData.expireTime) {
-    deleteExpiredSearchedCacheData(toCacheKey, cachedData.expireTime);
-  } else {
-    const searchText = response.config.url?.replace("/sick?q=", "");
-    if (searchText && searchText.length > 0)
-      cacheData(response.data, toCacheKey);
+  const searchText = response.config.url?.replace("/sick?q=", "");
+  if (cachedData.data.length === 0 && searchText?.length !== 0) {
+    cacheData(response.data, toCacheKey);
   }
   return response.data;
 });

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,6 +1,7 @@
 import axios, { isAxiosError } from "axios";
 import { BASE_URL } from "./config";
-import { getValidCacheData, cacheData, getLocalStorage } from "../utils";
+import { getValidCacheData, cacheData } from "../utils/cache";
+import { getLocalStorage } from "../utils/localStorage";
 
 export const CACHE_KEY_PREFIX = "cached_keyword_";
 

--- a/src/api/sick.ts
+++ b/src/api/sick.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from "react";
 import { SearchDispatchType } from "../reducers/type";
-import { sickApi } from "./http";
+import { cacheApi } from "./http";
 import { API } from "./config";
 
 export interface IResponseSick {
@@ -13,7 +13,7 @@ export const getSick = async (
 ) => {
   try {
     dispatch({ type: "SEARCH_LIST_REQUEST" });
-    const response: IResponseSick[] = await sickApi.get(
+    const response: IResponseSick[] = await cacheApi.get(
       `${API.SICK}?q=${searchKey}`,
     );
     if (response) {

--- a/src/context/SearchProvider.tsx
+++ b/src/context/SearchProvider.tsx
@@ -134,15 +134,13 @@ export const SearchProvider = ({
     ): number | null => {
       let updateIndex: number | null = focusedRecommendSearchItemIndex;
       if (event.key === "ArrowUp") {
-        updateIndex =
-          updateIndex === 0 || updateIndex === null
-            ? recommendedData.searchList.length - 1
-            : --updateIndex;
+        updateIndex = !updateIndex
+          ? recommendedData.searchList.length - 1
+          : --updateIndex;
       }
       if (event.key === "ArrowDown") {
         updateIndex =
-          (typeof updateIndex === "number" &&
-            updateIndex + 1 === recommendedData.searchList.length) ||
+          updateIndex === recommendedData.searchList.length - 1 ||
           updateIndex === null
             ? 0
             : ++updateIndex;

--- a/src/context/SearchProvider.tsx
+++ b/src/context/SearchProvider.tsx
@@ -101,9 +101,14 @@ export const SearchProvider = ({
   const typeSearchedKeyword = (
     e: React.ChangeEvent<HTMLInputElement>,
   ): void => {
+    const typedVal = e.target.value;
     setFocusedRecommendSearchItemIndex(null);
-    setSearchText(e.target.value);
-    debouncedUpdateSearchList(e.target.value);
+    setSearchText(typedVal);
+    if (typedVal.length === 0) {
+      dispatch({ type: "SEARCH_LIST_INIT", data: [] });
+    } else {
+      debouncedUpdateSearchList(typedVal);
+    }
   };
 
   const initSearchedKeyword = (callback: Function): void => {

--- a/src/context/SearchProvider.tsx
+++ b/src/context/SearchProvider.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { useNavigate } from "react-router-dom";
 import { initialState, reducer } from "../reducers/searchReducer";
-import { debounce } from "../utils";
+import { debounce } from "../utils/utils";
 import { getSick } from "../api/sick";
 import { handleError } from "../api/http";
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export interface ICacheData {
   expireTime: string | null;
 }
 
-export const cacheData = (toCacheData: string[], cacheKey: string): void => {
+export const cacheData = (toCacheData: any[], cacheKey: string): void => {
   window.localStorage.setItem(
     cacheKey,
     JSON.stringify({ expireTime: new Date().getTime(), data: toCacheData }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { IResponseSick } from "./api/sick";
+
 export const SECOND = 1000;
 export const MINUTE = SECOND * 60;
 export const EXPIRED_CACHED_SEARCH_TIME = MINUTE * 3;
@@ -7,7 +9,9 @@ export interface ICacheData {
   expireTime: string | null;
 }
 
-export const cacheData = (toCacheData: any[], cacheKey: string): void => {
+type CacheType = IResponseSick | string;
+
+export const cacheData = (toCacheData: CacheType[], cacheKey: string): void => {
   window.localStorage.setItem(
     cacheKey,
     JSON.stringify({ expireTime: new Date().getTime(), data: toCacheData }),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { IResponseSick } from "./api/sick";
 
 export const SECOND = 1000;
 export const MINUTE = SECOND * 60;
-export const EXPIRED_CACHED_SEARCH_TIME = MINUTE * 3;
+export const EXPIRED_CACHED_SEARCH_TIME = MINUTE;
 
 export interface ICacheData {
   data: string[];
@@ -11,27 +11,38 @@ export interface ICacheData {
 
 type CacheType = IResponseSick | string;
 
-export const cacheData = (toCacheData: CacheType[], cacheKey: string): void => {
+export const cacheData = (cacheKey: string, toCacheData: CacheType[]): void => {
   window.localStorage.setItem(
     cacheKey,
     JSON.stringify({ expireTime: new Date().getTime(), data: toCacheData }),
   );
 };
 
-export const getCacheData = (cacheKey: string): ICacheData => {
-  const val = window.localStorage.getItem(cacheKey);
+export const getLocalStorage = (storageKey: string): string | null => {
+  return window.localStorage.getItem(storageKey);
+};
+
+export const getCachedData = (cacheKey: string): ICacheData => {
+  const val = getLocalStorage(cacheKey);
   return val === null ? { data: [], expireTime: null } : JSON.parse(val);
 };
 
-export const deleteExpiredSearchedCacheData = (
+export const deleteExpiredCacheData = (
   cacheKey: string,
-  cachedDate: string,
+  cachedDate: number,
 ): void => {
-  const toNumberCachedDate: number = Number(cachedDate);
   const now = new Date().getTime();
-  if (now > toNumberCachedDate + EXPIRED_CACHED_SEARCH_TIME) {
+  if (now > cachedDate + EXPIRED_CACHED_SEARCH_TIME) {
     window.localStorage.removeItem(cacheKey);
   }
+};
+
+export const getValidCacheData = (cacheKey: string): ICacheData | null => {
+  const cachedData: ICacheData = getCachedData(cacheKey);
+  if (cachedData.expireTime) {
+    deleteExpiredCacheData(cacheKey, Number(cachedData.expireTime));
+  }
+  return getLocalStorage(cacheKey) ? cachedData : null;
 };
 
 export const debounce = (fn: Function, ms = 300) => {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,4 +1,5 @@
-import { IResponseSick } from "./api/sick";
+import { IResponseSick } from "../api/sick";
+import { getLocalStorage } from "./localStorage";
 
 export const SECOND = 1000;
 export const MINUTE = SECOND * 60;
@@ -16,10 +17,6 @@ export const cacheData = (cacheKey: string, toCacheData: CacheType[]): void => {
     cacheKey,
     JSON.stringify({ expireTime: new Date().getTime(), data: toCacheData }),
   );
-};
-
-export const getLocalStorage = (storageKey: string): string | null => {
-  return window.localStorage.getItem(storageKey);
 };
 
 export const getCachedData = (cacheKey: string): ICacheData => {
@@ -43,12 +40,4 @@ export const getValidCacheData = (cacheKey: string): ICacheData | null => {
     deleteExpiredCacheData(cacheKey, Number(cachedData.expireTime));
   }
   return getLocalStorage(cacheKey) ? cachedData : null;
-};
-
-export const debounce = (fn: Function, ms = 300) => {
-  let timeoutId: ReturnType<typeof setTimeout>;
-  return function (this: any, ...args: any[]) {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => fn.apply(this, args), ms);
-  };
 };

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,3 @@
+export const getLocalStorage = (storageKey: string): string | null => {
+  return window.localStorage.getItem(storageKey);
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,7 @@
+export const debounce = (fn: Function, ms = 300) => {
+  let timeoutId: ReturnType<typeof setTimeout>;
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn.apply(this, args), ms);
+  };
+};


### PR DESCRIPTION
참고사항

캐싱 저장 로직
저장될 캐싱 데이터는 서버로부터 받은 정보이며 서버로부터 받은 정보를 그대로 저장하고자 합니다.
이때 서버로부터 받을 배열의 데이터의 요소가 어떠한 데이터 타입인지 예측하기 힘들기에 타입 별칭을 따로 마련했습니다.

캐싱 삭제 순서
axios request 부분에서 캐싱 데이터가 있는지 탐색 후 캐싱 데이터를 바로 주면 안된다고 생각합니다.
왜냐하면 해당 캐싱데이터가 만료기간이 지났을 수도 있기 때문입니다.
캐싱된 데이터를 주기 전에 만료기간이 지났으며 레거시 정보를 주는 것을 방지하기 위해 캐싱 삭제 여부 로직을 instance request부분으로 옮겼습니다.